### PR TITLE
Initial Implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+OPTIONS=-e ssh --relative --compress --archive --progress --human-readable
+
+# Make sure to set CAPTURED_DEPLOY_SERVER to the server you want to rsync to.
+# The syntax might look like this:
+#
+# export CAPTURED_DEPLOY_SERVER="username@hostname.com:path/to/php/dir/"
+#
+SERVER=$(CAPTURED_DEPLOY_SERVER)
+
+all: deploy
+deploy:
+	rsync $(OPTIONS) ./ $(SERVER) --exclude="Makefile" --exclude="*DS_Store" --exclude=".git"
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Captured PHP Upload Script
+This is a simple script that can provide a target for [Captured App](http://www.capturedapp.com/) to upload to any webserver that supports PHP.
+
+### Installation
+
+1. Download and modify `captured.php`'s configuration options, setting the upload directory and api token.
+1. Upload the `captured.php` file to your host, to a directory configured to serve PHP scripts.
+1. Configure Captured.app with the URL to the script and the API Token you created in step 1.
+
+If you have `mod_env` avaliable on your host, you might want to pass the token to the script via an ENV variable. This might be done via the `.htaccess` file:
+
+```
+SetEnv CAPTURED_TOKEN change_this_token
+SetEnv CAPTURED_UPLOAD_DIR /home/user/website.com/upload-dir/
+```
+
+### Usage
+
+This script is indtended to be used with Captured App's "Captured PHP" uploader.
+
+For testing purposes you can use `curl` to test the script directly:
+
+```
+curl -i -X POST \
+  -F "token=iuqb8nXExseZZjvPmrWYAmA9MVZjjZvr" \
+  -F "file=@test.jpg" \
+   http://example.com/captured.php
+```

--- a/captured.php
+++ b/captured.php
@@ -1,0 +1,109 @@
+<?php
+////////////////////////////////////////////////////////////////////////////////
+//
+// Captured PHP Upload Script
+//
+// This is a simple script that can provide a target for Captured App to upload
+// to any webserver that supports PHP. For more details or to get Captured
+// visit:
+//
+// http://www.capturedapp.com/
+//
+////////////////////////////////////////////////////////////////////////////////
+//
+// Configuration Options
+//
+// The folling options can either be set with the corresponding envioment
+// variables or by manually changing the options in the script below.
+//
+// To set the envioment variables in a `.htaccess` file you can do the following:
+//
+// SetEnv CAPTURED_TOKEN change_this_token
+// SetEnv CAPTURED_UPLOAD_DIR /home/user/website.com/upload-dir/
+//
+////////////////////////////////////////////////////////////////////////////////
+//
+// API Token used to authenticate requests. Do not use the default.
+//
+$API_TOKEN=$_ENV["CAPTURED_API_TOKEN"] ?: "change_this_token";
+//
+// Upload Directory. Needs to be writable by PHP on this server. Does not have
+// to be publically served, since this script will proxy images back.
+//
+$UPLOAD_DIR = $_ENV["CAPTURED_UPLOAD_DIR"] ?: "./uploads/";
+//
+////////////////////////////////////////////////////////////////////////////////
+
+function jecho($arr) {
+  echo json_encode($arr, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+}
+
+function join_paths() {
+  $paths = array();
+  foreach (func_get_args() as $arg) {
+    if ($arg !== '') { $paths[] = $arg; }
+  }
+  return preg_replace('#/+#','/',join('/', $paths));
+}
+
+function randomish($length = 8) {
+  $characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  $string = '';
+
+  for ($i = 0; $i < $length; $i++) {
+    $string .= $characters[mt_rand(0, strlen($characters) - 1)];
+  }
+  return $string;
+}
+
+function enforce_token() {
+  global $API_TOKEN;
+  if($_POST['token'] != $API_TOKEN) {
+    print_r($_POST);
+    http_response_code(401);
+    jecho(['error' => "Invalid Token"]);
+    exit();
+  }
+}
+
+function render_image() {
+  global $UPLOAD_DIR;
+  $file = join_paths($UPLOAD_DIR, basename($_GET['i']));
+  if (file_exists($file)) {
+    header("Content-Type: image/" . pathinfo($file, PATHINFO_EXTENSION));
+    readfile($file);
+    exit();
+  } else {
+    http_response_code(404);
+    jecho(['error' => "File Not Found"]);
+  }
+}
+
+function process_image_upload() {
+  global $UPLOAD_DIR;
+
+  if(!is_dir($UPLOAD_DIR)) { mkdir($UPLOAD_DIR); }
+
+  $protocol= (empty($_SERVER['HTTPS'])) ? 'http://' : 'https://';
+  $ext = pathinfo($_FILES['file']['name'], PATHINFO_EXTENSION);
+  $upload_name = randomish() . '.' . $ext;
+  $upload_file = join_paths($UPLOAD_DIR, $upload_name);
+  $public_url = $protocol . $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI'] . "/?i=" . $upload_name;
+
+  header('Content-Type: application/json');
+
+  if (move_uploaded_file($_FILES['file']['tmp_name'], $upload_file)) {
+    jecho(["public_url" => $public_url]);
+  } else {
+    jecho(['error' => "Unable to process image upload"]);
+  }
+}
+
+if($_SERVER['REQUEST_METHOD'] == 'POST') {
+  enforce_token();
+  process_image_upload();
+} else {
+  render_image();
+}
+
+?>

--- a/captured.php
+++ b/captured.php
@@ -59,14 +59,13 @@ function randomish($length = 8) {
 function enforce_token() {
   global $API_TOKEN;
   if($_POST['token'] != $API_TOKEN) {
-    print_r($_POST);
     http_response_code(401);
-    jecho(['error' => "Invalid Token"]);
+    jecho(['status' => "401 Invalid Token"]);
     exit();
   }
 }
 
-function render_image() {
+function render_file() {
   global $UPLOAD_DIR;
   $file = join_paths($UPLOAD_DIR, basename($_GET['i']));
   if (file_exists($file)) {
@@ -75,14 +74,24 @@ function render_image() {
     exit();
   } else {
     http_response_code(404);
-    jecho(['error' => "File Not Found"]);
+    jecho(['status' => "404 File Not Found"]);
   }
 }
 
-function process_image_upload() {
+function process_test_connection() {
+  if($_POST['test'] == "true") {
+    http_response_code(202);
+    jecho(['status' => "202 Accepted"]);
+    exit();
+  }
+}
+
+function process_file_upload() {
   global $UPLOAD_DIR;
 
   if(!is_dir($UPLOAD_DIR)) { mkdir($UPLOAD_DIR); }
+
+  header('Content-Type: application/json');
 
   $protocol= (empty($_SERVER['HTTPS'])) ? 'http://' : 'https://';
   $ext = pathinfo($_FILES['file']['name'], PATHINFO_EXTENSION);
@@ -90,20 +99,21 @@ function process_image_upload() {
   $upload_file = join_paths($UPLOAD_DIR, $upload_name);
   $public_url = $protocol . $_SERVER['SERVER_NAME'] . $_SERVER['REQUEST_URI'] . "/?i=" . $upload_name;
 
-  header('Content-Type: application/json');
 
   if (move_uploaded_file($_FILES['file']['tmp_name'], $upload_file)) {
     jecho(["public_url" => $public_url]);
   } else {
-    jecho(['error' => "Unable to process image upload"]);
+    jecho(['error' => "Unable to process file upload"]);
   }
+
 }
 
 if($_SERVER['REQUEST_METHOD'] == 'POST') {
   enforce_token();
-  process_image_upload();
+  process_test_connection();
+  process_file_upload();
 } else {
-  render_image();
+  render_file();
 }
 
 ?>


### PR DESCRIPTION
Creates a script that uses a token to authenticate uploads and proxies the images back to the browser.

The token is posted as part of the form. I did this because reading headers relies on a specific web server API to access (e.g. Apache). So it seemed like it would be more consistent to just use a form field.

The UPLOAD_DIR does not have it's content served publicly like I originally planned. Instead the script will use `readfile` to proxy it back to the requester. This allows that directory to be located out of
the website and prevents scripts from being run.

Configuration can be handled by environment variables, but doesn't have to be. There is a way to modify this script to set the token and upload directory path.

I used the `global` keyword a few times. Pretty sure this is a Bad Idea™, but it seemed like a good idea at the time. What could go wrong?
